### PR TITLE
Filter list of available authorized dashboards

### DIFF
--- a/src/DashboardNova.php
+++ b/src/DashboardNova.php
@@ -40,7 +40,10 @@ class DashboardNova extends Nova
      */
     public static function availableDashboards(Request $request)
     {
-        return collect(static::$dashboards)->all();
+        return collect(static::$dashboards)
+            ->filter
+            ->authorize($request)
+            ->all();
     }
 
     /**


### PR DESCRIPTION
This commit filters the dashboard list so that the navigation will not show Dashboards the user is not authorized to see (via the authorize() method on the dashboards. This allows for different sets of dashboard depending on authorization policies.