### PR TITLE
allow ordering of dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ There is now a `php artisan nova:dashboard <name>` command exposed via the CLI.
 
 If you run this, you'll get a `App/Nova/Dashboards` directory created, which will house your custom dashboards.
 
+Dashboards have a `public $order` variable you can use to set the order they appear in the navbar. See the `Dashboard` class for more.
+
 If you are another package creating a nova dashboard, you will need to register it using:
 
 ```php

--- a/src/Dashboard.php
+++ b/src/Dashboard.php
@@ -6,5 +6,5 @@ use Laravel\Nova\Element;
 
 abstract class Dashboard extends Element
 {
-    //
+    public $sort;
 }

--- a/src/DashboardNova.php
+++ b/src/DashboardNova.php
@@ -78,13 +78,13 @@ class DashboardNova extends Nova
         }
 
         static::dashboards(
-            collect($dashboards)->sort()->transform(function ($dashboard) {
+            collect($dashboards)->transform(function ($dashboard) {
                 if ($dashboard instanceof Dashboard) {
                     return $dashboard;
                 }
 
                 return app()->make($dashboard);
-            })->all()
+            })->sortBy('order')->all()
         );
     }
 

--- a/src/DashboardNova.php
+++ b/src/DashboardNova.php
@@ -84,7 +84,7 @@ class DashboardNova extends Nova
                 }
 
                 return app()->make($dashboard);
-            })->sortBy('order')->all()
+            })->sortBy('label')->sortBy('order')->all()
         );
     }
 


### PR DESCRIPTION
This seemed to be the simplest way to allow users to set the order of the dashboards; I considered hijacking `meta` array for this, but I didn't want to interfere with how other projects might try to use that array & this keeps it "nice and tight" for our own use.

Happy to rename, tweak, etc